### PR TITLE
Fix: Close socket and unregister buffers in ujrpc_free

### DIFF
--- a/src/engine_posix.cpp
+++ b/src/engine_posix.cpp
@@ -372,6 +372,7 @@ void ujrpc_free(ujrpc_server_t server) {
         return;
 
     engine_t& engine = *reinterpret_cast<engine_t*>(server);
+    close(engine.socket);
     engine.~engine_t();
     std::free(server);
 }

--- a/src/engine_uring.cpp
+++ b/src/engine_uring.cpp
@@ -435,7 +435,9 @@ void ujrpc_free(ujrpc_server_t server) {
         return;
 
     engine_t& engine = *reinterpret_cast<engine_t*>(server);
+    io_uring_unregister_buffers(&engine.uring);
     io_uring_queue_exit(&engine.uring);
+    close(engine.socket);
     engine.~engine_t();
     std::free(server);
 }


### PR DESCRIPTION
Without cleaning these up, subsequent initializations will fail  with "Address already in use" and also "Invalid Argument" from io_uring_register_buffers.