### PR TITLE
Wrap the error message with double quote to make it a valid JSON.

### DIFF
--- a/src/protocol_rest.hpp
+++ b/src/protocol_rest.hpp
@@ -68,18 +68,15 @@ inline bool protocol_rest_t::append_response(exchange_pipes_t& pipes, std::strin
 
 inline bool protocol_rest_t::append_error(exchange_pipes_t& pipes, std::string_view error_code,
                                           std::string_view message) noexcept {
-    std::string wrappedMessage = std::string("\"") + std::string(message) + "\"";
-
-
     if (!pipes.append_outputs({R"({"error":)", 9}))
         return false;
     if (!pipes.append_outputs(error_code))
         return false;
-    if (!pipes.append_outputs({R"(,"message":)", 11}))
+    if (!pipes.append_outputs({R"(,"message":")", 11}))
         return false;
-    if (!pipes.append_outputs(wrappedMessage))
+    if (!pipes.append_outputs(message))
         return false;
-    if (!pipes.append_outputs({"}", 1}))
+    if (!pipes.append_outputs({R"("})", 1}))
         return false;
     return true;
 };

--- a/src/protocol_rest.hpp
+++ b/src/protocol_rest.hpp
@@ -68,6 +68,8 @@ inline bool protocol_rest_t::append_response(exchange_pipes_t& pipes, std::strin
 
 inline bool protocol_rest_t::append_error(exchange_pipes_t& pipes, std::string_view error_code,
                                           std::string_view message) noexcept {
+    std::string wrappedMessage = std::string("\"") + std::string(message) + "\"";
+
 
     if (!pipes.append_outputs({R"({"error":)", 9}))
         return false;
@@ -75,7 +77,7 @@ inline bool protocol_rest_t::append_error(exchange_pipes_t& pipes, std::string_v
         return false;
     if (!pipes.append_outputs({R"(,"message":)", 11}))
         return false;
-    if (!pipes.append_outputs(message))
+    if (!pipes.append_outputs(wrappedMessage))
         return false;
     if (!pipes.append_outputs({"}", 1}))
         return false;


### PR DESCRIPTION
The response that returned by REST mode is not a valid JSON.
![image](https://github.com/unum-cloud/ucall/assets/2534060/85597749-837c-4d0d-9463-4bebcc7d22d5)

I just added double quote around the error message. After:
![image](https://github.com/unum-cloud/ucall/assets/2534060/5f2c5c87-af6f-4aac-bbbb-a9379c3c5414)
