### PR TITLE
Posix net.hpp refactor for reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build_release/
 CMakeFiles
 _deps
 build/
+dist/
 cmake_install.cmake
 CMakeCache.txt
 Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ cmake_install.cmake
 CMakeCache.txt
 Makefile
 *.log
+*.swp
 _deps
 CMakeFiles
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if(MSVC)
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
@@ -107,7 +108,8 @@ include_directories(${cxxopts_SOURCE_DIR}/include)
 # export CPATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/
 FetchContent_Declare(
     picohttpparser
-    GIT_REPOSITORY https://github.com/unum-cloud/picohttpparser.git
+    #GIT_REPOSITORY https://github.com/unum-cloud/picohttpparser.git
+    GIT_REPOSITORY https://github.com/MarkReedZ/picohttpparser.git
     GIT_SHALLOW 1
 )
 FetchContent_MakeAvailable(picohttpparser)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,21 +123,6 @@ FetchContent_MakeAvailable(tb64)
 include_directories(${tb64_SOURCE_DIR})
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-FetchContent_Declare(
-    mbedtls
-    GIT_REPOSITORY https://github.com/Mbed-TLS/mbedtls/
-    GIT_TAG v3.4.0
-    CMAKE_ARGS
-    -DENABLE_PROGRAMS=OFF
-    -DENABLE_TESTING=OFF
-    -DUSE_SHARED_MBEDTLS_LIBRARY=OFF
-    -DUSE_STATIC_MBEDTLS_LIBRARY=ON
-)
-
-FetchContent_MakeAvailable(mbedtls)
-include_directories(${mbedtls_SOURCE_DIR}/include)
-set(mbedtls_LIBS mbedtls mbedcrypto mbedx509)
-
 # LibUring
 if(LINUX)
     set(URING_DIR ${CMAKE_BINARY_DIR}/_deps/liburing-ep)
@@ -168,7 +153,7 @@ find_package(Threads REQUIRED)
 include_directories(include/ src/)
 
 add_library(ucall_server_posix src/engine_posix.cpp)
-target_link_libraries(ucall_server_posix simdjson::simdjson Threads::Threads ${mbedtls_LIBS})
+target_link_libraries(ucall_server_posix simdjson::simdjson Threads::Threads )
 set(PYTHON_BACKEND ucall_server_posix)
 
 add_executable(ucall_example_login_posix examples/login/ucall_server.cpp)

--- a/src/engine_posix.cpp
+++ b/src/engine_posix.cpp
@@ -91,20 +91,13 @@ sj::simdjson_result<sjd::element> param_at(ucall_call_t call, size_t position) n
 }
 
 void send_message(engine_t& engine, array_gt<char> const& message) noexcept {
-    char const* buf = message.data();
-    size_t const len = message.size();
-    long idx = 0;
-    long res = 0;
-
-    while (idx < len && (res = send(engine.connection, buf + idx, len - idx, 0)) > 0)
-        idx += res;
-
+    int res = net_send_message( engine.connection, message );
     if (res < 0) {
         if (errno == EMSGSIZE)
             ucall_call_reply_error_out_of_memory(&engine);
         return;
     }
-    engine.stats.bytes_sent += idx;
+    engine.stats.bytes_sent += message.size();
     engine.stats.packets_sent++;
 }
 

--- a/src/helpers/net.hpp
+++ b/src/helpers/net.hpp
@@ -93,4 +93,23 @@ inline void net_shutdown(ucall_server_t &server) noexcept {
     close(socket_fd);
 }
 
+/**
+ * @brief 
+ */
+int net_send_message(int fd, array_gt<char> const& message) noexcept {
+    char const* buf = message.data();
+    size_t const len = message.size();
+    long idx = 0;
+    long res = 0;
+                              
+    while (idx < len && (res = send(fd, buf + idx, len - idx, 0)) > 0)
+        idx += res;
+
+    if (res < 0) {
+        return res;
+    }
+    return 0;
+}
+
+
 } // namespace

--- a/src/helpers/net.hpp
+++ b/src/helpers/net.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "shared.hpp"
+#include "ucall/ucall.h" // ucall_config_t
+
+namespace unum::ucall {
+
+struct conn_t {
+    ~conn_t() noexcept { }
+
+    int fd{};
+    /// @brief A small memory buffer to store small requests.
+    alignas(align_k) char packet_buffer[4 * ram_page_size_k + sj::SIMDJSON_PADDING]{};
+    void *user_data;
+};
+
+static int socket_fd;
+static int(*data_cb)(conn_t *, char *, int );
+/**
+ * @brief 
+ */
+inline int net_init(ucall_config_t& config, int(*cb)(conn_t *, char *, int )) noexcept {
+    if ( cb == NULL ) return -1;
+    data_cb = cb;
+
+    int socket_options{1};
+
+    // By default, let's open TCP port for IPv4.
+    struct sockaddr_in address;
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = inet_addr(config.hostname);
+    address.sin_port = htons(config.port);
+
+    socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (socket_fd < 0)
+        goto cleanup;
+    // Optionally configure the socket, but don't always expect it to succeed.
+    if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT,
+                   reinterpret_cast<char const*>(&socket_options), sizeof(socket_options)) == -1)
+        errno;
+    if (bind(socket_fd, (struct sockaddr*)&address, sizeof(address)) < 0)
+        goto cleanup;
+    if (listen(socket_fd, config.queue_depth) < 0)
+        goto cleanup;
+
+    return socket_fd;
+
+cleanup:
+    if (socket_fd >= 0)
+        close(socket_fd);
+
+    return -1;
+}
+
+/**
+ * @brief 
+ */
+inline void net_run(void *user_data) noexcept {
+    
+    while(true) {
+
+        int fd = accept(socket_fd, (struct sockaddr*)NULL, NULL);
+        if (fd < 0) { errno; return; }
+    
+        conn_t *conn = (conn_t*)std::malloc(sizeof(conn_t));
+        conn->user_data = user_data;
+        conn->fd = fd;
+
+        char* buffer_ptr = &conn->packet_buffer[0];
+        size_t n = 0, bytes_expected = 0;
+        n = recv(fd, buffer_ptr, ram_page_size_k, 0);
+        int remaining = data_cb( conn, buffer_ptr, n );
+        while ( remaining > 0 ) {
+            n = recv(fd, buffer_ptr+remaining, ram_page_size_k, 0);
+            remaining = data_cb( conn, buffer_ptr, n+remaining );
+        }
+        
+        std::free(conn);
+        close(fd);
+    }
+/*
+#if defined(UCALL_IS_WINDOWS)
+        _aligned_free(buffer_ptr);
+#else
+        std::free(buffer_ptr);
+#endif
+*/
+}
+/**
+ * @brief 
+ */
+inline void net_shutdown(ucall_server_t &server) noexcept {
+    close(socket_fd);
+}
+
+} // namespace

--- a/src/helpers/parse.hpp
+++ b/src/helpers/parse.hpp
@@ -60,8 +60,7 @@ template <std::size_t step_ak> constexpr std::size_t round_up_to(std::size_t n) 
 /**
  * @brief Validates the contents of the JSON call DOM, and finds a matching callback.
  */
-template <typename named_callbacks_at>
-inline std::variant<named_callback_t, default_error_t> find_callback(named_callbacks_at const& callbacks,
+inline std::variant<named_callback_t, default_error_t> find_callback(std::map<std::string_view, named_callback_t> & cbmap,
                                                                      scratch_space_t& scratch) noexcept {
     sjd::element const& doc = scratch.tree;
     if (!doc.is_object())
@@ -100,15 +99,12 @@ inline std::variant<named_callback_t, default_error_t> find_callback(named_callb
         scratch.dynamic_id = "";
 
     // Make sure we have such a method:
-    auto method_name = method.get_string().value_unsafe();
-    auto callbacks_end = callbacks.data() + callbacks.size();
-    auto callback_it = std::find_if(callbacks.data(), callbacks_end, [=](named_callback_t const& callback) noexcept {
-        return callback.name == method_name;
-    });
-    if (callback_it == callbacks_end)
+    auto it = cbmap.find( method.get_string().value_unsafe() );
+    if (it == cbmap.end())
         return default_error_t{-32601, "Method not found."};
 
-    return *callback_it;
+    return it->second;
+
 }
 
 struct parsed_request_t {

--- a/src/helpers/parse.hpp
+++ b/src/helpers/parse.hpp
@@ -139,7 +139,6 @@ inline std::variant<parsed_request_t, default_error_t> split_body_headers(std::s
 
     int res = phr_parse_request(body.data(), body.size(), &method, &method_len, &path, &path_len, &minor_version,
                                 headers, &count_headers, 0);
-
     if (res == -2)
         return default_error_t{-2, "Partial HTTP request"};
 
@@ -164,7 +163,7 @@ inline std::variant<parsed_request_t, default_error_t> split_body_headers(std::s
         req.body = body.substr(pos + 4);
     } else
         req.body = body;
-
+    
     return req;
 }
 


### PR DESCRIPTION
My thought for the refactor was to create a net.hpp ( later net-uring.hpp / net-posix.hpp ) to handle the networking using a common engine.cpp.  This is a prototype for the posix engine only.  Not expected to be merged though tests pass and python works though I didn't add python tests.

net_init is called passing an on_data function.  
 
```
  fd = net_init(config, on_data);

 int on_data(conn_t *conn, char *buf, int data_left) {
    engine_t& engine = *reinterpret_cast<engine_t*>(conn->user_data);

```

Interesting things:

- Posix now handles large requests > 4096 and partial requests.   In the on_data function you return the data left after parsing and the next on_data call will contain the remaining + new data. 
- I use a map for the callbacks. I updated engine-uring.cpp with this so you can see it below
- We detect json by looking at the first character and handle json and http separately
- take_call is not supported so python uses take_calls
