### PR TITLE
Fix benchmark

### DIFF
--- a/examples/bench.py
+++ b/examples/bench.py
@@ -131,7 +131,10 @@ def bench_parallel(
 
 def main(class_name: str, *, threads: int = 1, requests: int = 100_000, seconds: float = 10, progress: bool = False):
     script_dir = os.path.dirname(os.path.abspath(__file__))
+    project_dir = os.path.dirname(script_dir)
     sys.path.append(f'{script_dir}/login')
+    sys.path.append(os.path.join(project_dir, 'src'))
+
     class_ = locate(class_name)
     stats = bench_parallel(
         callable=class_(),

--- a/examples/login/README.md
+++ b/examples/login/README.md
@@ -1,7 +1,6 @@
-# Summation Examples and Benchmarks
+# Login Examples and Benchmarks
 
-The simplest possible endpoint after `hello-world` and `echo`, is probably `sum`.
-We would just accept two numbers and return their aggregate.
+This is an example of a simple login client and server.
 Packets are tiny, so it is great for benchmarking the request latency.
 
 ## Reproducing Benchmarks
@@ -10,7 +9,7 @@ Packets are tiny, so it is great for benchmarking the request latency.
 
 ```sh
 pip install uvicorn fastapi websocket-client requests tqdm fire
-cd examples && uvicorn sum.fastapi_server:app --log-level critical &
+cd examples && uvicorn login.fastapi_server:app --log-level critical &
 cd ..
 python examples/bench.py "fastapi_client.ClientREST" --progress
 python examples/bench.py "fastapi_client.ClientWebSocket" --progress
@@ -27,13 +26,13 @@ python examples/bench.py "fastapi_client.ClientWebSocket" --threads 8
 ### UCall
 
 UCall can produce both a POSIX compliant old-school server, and a modern `io_uring`-based version for Linux kernel 5.19 and newer.
-You would either run `ucall_example_sum_posix` or `ucall_example_sum_uring`.
+You would either run `ucall_example_login_posix` or `ucall_example_login_uring`.
 
 ```sh
 sudo apt-get install cmake g++ build-essential
 cmake -DCMAKE_BUILD_TYPE=Release -B ./build_release  && make -C ./build_release
-./build_release/build/bin/ucall_example_sum_posix &
-./build_release/build/bin/ucall_example_sum_uring &
+./build_release/build/bin/ucall_example_login_posix &
+./build_release/build/bin/ucall_example_login_uring &
 python examples/bench.py "jsonrpc_client.CaseTCP" --progress
 python examples/bench.py "jsonrpc_client.CaseHTTP" --progress
 python examples/bench.py "jsonrpc_client.CaseHTTPBatches" --progress
@@ -43,7 +42,7 @@ kill %%
 Want to customize server settings?
 
 ```sh
-./build_release/build/bin/ucall_example_sum_uring --nic=127.0.0.1 --port=8545 --threads=16 --silent=false
+./build_release/build/bin/ucall_example_login_uring --nic=127.0.0.1 --port=8545 --threads=16 --silent=false
 ```
 
 Want to dispatch more clients and aggregate more accurate statistics?


### PR DESCRIPTION
Fix running benchmark without installing ucall and update benchmark running instructions.

Before:

```
$ ./build_release/build/bin/ucall_example_login_posix &
$ python examples/bench.py "jsonrpc_client.CaseTCP" --progress
Traceback (most recent call last):
  File "/home/ubuntu/miniconda3/lib/python3.12/pydoc.py", line 451, in safeimport
    module = importlib.import_module(path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/miniconda3/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/ubuntu/ucall-viz/examples/login/jsonrpc_client.py", line 11, in <module>
    from ucall.client import Client
ModuleNotFoundError: No module named 'ucall'
```

After:

```
$ ./build_release/build/bin/ucall_example_login_posix &
$ python examples/bench.py "jsonrpc_client.CaseTCP" --progress
- Took: 4.5 CPU seconds
- Total exchanges: 100,000
- Success rate: 100.000%
- Mean latency: 45.1 microseconds
- Mean bandwidth: 22169.3 requests/s
```
```