### PR TITLE
Update the python module directory

### DIFF
--- a/examples/bench.py
+++ b/examples/bench.py
@@ -142,7 +142,7 @@ def main(
     script_dir = os.path.dirname(os.path.abspath(__file__))
     project_dir = os.path.dirname(script_dir)
     sys.path.append(f"{script_dir}/login")
-    sys.path.append(os.path.join(project_dir, "src"))
+    sys.path.append(os.path.join(project_dir, "python"))
 
     class_ = locate(class_name)
     stats = bench_parallel(


### PR DESCRIPTION
The python module has been moved from `src` to `python`. This will make the benchmark work without installation again.