### PR TITLE
Tag the sqe's to fix the fsm handling a double send cqe

### DIFF
--- a/src/engine_uring.cpp
+++ b/src/engine_uring.cpp
@@ -69,7 +69,6 @@
 #include "helpers/reply.hpp"
 #include "helpers/shared.hpp"
 
-
 #pragma region Cpp Declaration
 
 namespace sj = simdjson;
@@ -831,7 +830,6 @@ void engine_t::submit_stats_heartbeat() noexcept {
 
     uring_sqe = io_uring_get_sqe(&uring);
     io_uring_prep_timeout(uring_sqe, &connection.next_wakeup, 0, 0);
-    //io_uring_sqe_set_data(uring_sqe, &connection);
     io_uring_sqe_set_data(uring_sqe, (void*)((uring_stat_tag_k<<60) | uint64_t(&connection)));
     uring_result = io_uring_submit(&uring);
     submission_mutex.unlock();
@@ -1000,7 +998,6 @@ void automata_t::operator()() noexcept {
         if (completed_result == 0) {
             connection.empty_transmits++;
             return should_release() ? close_gracefully() : receive_next();
-            //return close_gracefully();
         }
 
         // Absorb the arrived data.

--- a/src/engine_uring.cpp
+++ b/src/engine_uring.cpp
@@ -69,6 +69,7 @@
 #include "helpers/reply.hpp"
 #include "helpers/shared.hpp"
 
+
 #pragma region Cpp Declaration
 
 namespace sj = simdjson;
@@ -89,6 +90,11 @@ struct connection_t;
 struct engine_t;
 struct automata_t;
 
+static constexpr std::size_t uring_recv_tag_k{1};
+static constexpr std::size_t uring_send_tag_k{2};
+static constexpr std::size_t uring_stat_tag_k{3};
+static constexpr std::size_t uring_acpt_tag_k{4};
+
 enum class stage_t {
     waiting_to_accept_k = 0,
     expecting_reception_k,
@@ -102,6 +108,7 @@ struct completed_event_t {
     connection_t* connection_ptr{};
     stage_t stage{};
     int result{};
+    uint64_t type{};
 };
 
 class alignas(align_k) mutex_t {
@@ -250,6 +257,7 @@ struct automata_t {
     connection_t& connection;
     stage_t completed_stage{};
     int completed_result{};
+    uint64_t type{};
 
     void operator()() noexcept;
     bool is_corrupted() const noexcept { return completed_result == -EPIPE || completed_result == -EBADF; }
@@ -471,6 +479,7 @@ void ucall_take_call(ucall_server_t server, uint16_t thread_idx) {
             *completed.connection_ptr,
             completed.stage,
             completed.result,
+            completed.type,
         };
 
         // If everything is fine, let automata work in its normal regime.
@@ -755,7 +764,9 @@ template <std::size_t max_count_ak> std::size_t engine_t::pop_completed(complete
         ++passed;
         if (!uring_cqe->user_data)
             continue;
-        events[completed].connection_ptr = (connection_t*)uring_cqe->user_data;
+
+        events[completed].connection_ptr = (connection_t*)(uring_cqe->user_data & 0x0fffffffffffffff);
+        events[completed].type = (uring_cqe->user_data >> 60) & 0xF;// & 0xf000000000000000;
         events[completed].stage = events[completed].connection_ptr->stage;
         events[completed].result = uring_cqe->res;
         ++completed;
@@ -790,7 +801,7 @@ bool engine_t::consider_accepting_new_connection() noexcept {
     uring_sqe = io_uring_get_sqe(&uring);
     io_uring_prep_accept_direct(uring_sqe, socket, &connection.client_address, &connection.client_address_len, 0,
                                 IORING_FILE_INDEX_ALLOC);
-    io_uring_sqe_set_data(uring_sqe, &connection);
+    io_uring_sqe_set_data(uring_sqe, (void*)((uring_acpt_tag_k<<60) | uint64_t(&connection)));
 
     // Accepting new connections can be time-less.
     // io_uring_sqe_set_flags(uring_sqe, IOSQE_IO_LINK);
@@ -820,7 +831,8 @@ void engine_t::submit_stats_heartbeat() noexcept {
 
     uring_sqe = io_uring_get_sqe(&uring);
     io_uring_prep_timeout(uring_sqe, &connection.next_wakeup, 0, 0);
-    io_uring_sqe_set_data(uring_sqe, &connection);
+    //io_uring_sqe_set_data(uring_sqe, &connection);
+    io_uring_sqe_set_data(uring_sqe, (void*)((uring_stat_tag_k<<60) | uint64_t(&connection)));
     uring_result = io_uring_submit(&uring);
     submission_mutex.unlock();
 }
@@ -892,7 +904,7 @@ void automata_t::send_next() noexcept {
         uring_sqe->flags |= IOSQE_FIXED_FILE;
         uring_sqe->buf_index = engine.connections.offset_of(connection) * 2u + 1u;
     }
-    io_uring_sqe_set_data(uring_sqe, &connection);
+    io_uring_sqe_set_data(uring_sqe, (void*)((uring_send_tag_k<<60) | uint64_t(&connection)));
     io_uring_sqe_set_flags(uring_sqe, 0);
     uring_result = io_uring_submit(&engine.uring);
     engine.submission_mutex.unlock();
@@ -918,7 +930,7 @@ void automata_t::receive_next() noexcept {
     uring_sqe = io_uring_get_sqe(&engine.uring);
     io_uring_prep_read_fixed(uring_sqe, int(connection.descriptor), (void*)pipes.next_input_address(),
                              pipes.next_input_length(), 0, engine.connections.offset_of(connection) * 2u);
-    io_uring_sqe_set_data(uring_sqe, &connection);
+    io_uring_sqe_set_data(uring_sqe, (void*)((uring_recv_tag_k<<60) | uint64_t(&connection)));
     io_uring_sqe_set_flags(uring_sqe, IOSQE_IO_LINK);
 
     // More than other operations this depends on the information coming from the client.
@@ -942,6 +954,9 @@ void automata_t::operator()() noexcept {
     switch (connection.stage) {
 
     case stage_t::waiting_to_accept_k:
+        if ( type != uring_acpt_tag_k ) {
+            return;
+        }
 
         if (completed_result == -ECANCELED) {
             engine.release_connection(connection);
@@ -959,6 +974,9 @@ void automata_t::operator()() noexcept {
 
     case stage_t::expecting_reception_k:
 
+        if ( type != uring_recv_tag_k ) {
+            return;
+        }
         // From documentation:
         // > If used, the timeout specified in the command will cancel the linked command,
         // > unless the linked command completes before the timeout. The timeout will complete
@@ -982,6 +1000,7 @@ void automata_t::operator()() noexcept {
         if (completed_result == 0) {
             connection.empty_transmits++;
             return should_release() ? close_gracefully() : receive_next();
+            //return close_gracefully();
         }
 
         // Absorb the arrived data.

--- a/src/engine_uring.cpp
+++ b/src/engine_uring.cpp
@@ -947,7 +947,8 @@ void automata_t::receive_next() noexcept {
 void automata_t::operator()() noexcept {
 
     if (is_corrupted())
-        return close_gracefully();
+        if ( connection.stage != stage_t::waiting_to_close_k )
+            return close_gracefully();
 
     switch (connection.stage) {
 

--- a/src/engine_uring.cpp
+++ b/src/engine_uring.cpp
@@ -736,7 +736,7 @@ void automata_t::parse_and_raise_request() noexcept {
 
     auto parsed_request = std::get<parsed_request_t>(parsed_request_or_error);
     scratch.is_http = request.size() != parsed_request.body.size();
-    scratch.dynamic_packet = parsed_request.body;
+    scratch.dynamic_packet = {parsed_request.body.data(), parsed_request.json_length};
     if (scratch.dynamic_packet.size() > ram_page_size_k) {
         sjd::parser parser;
         if (parser.allocate(scratch.dynamic_packet.size(), scratch.dynamic_packet.size() / 2) != sj::SUCCESS)

--- a/src/helpers/parse.hpp
+++ b/src/helpers/parse.hpp
@@ -67,7 +67,6 @@ inline std::variant<named_callback_t, default_error_t> find_callback(named_callb
     if (!doc.is_object())
         return default_error_t{-32600, "The JSON sent is not a valid request object."};
 
-
     // We don't support JSON-RPC before version 2.0.
     sj::simdjson_result<sjd::element> version = doc["jsonrpc"];
     if (!version.is_string() || version.get_string().value_unsafe() != "2.0")

--- a/src/helpers/parse.hpp
+++ b/src/helpers/parse.hpp
@@ -119,7 +119,7 @@ struct parsed_request_t {
     std::string_view content_type{};
     std::string_view content_length{};
     std::string_view body{};
-    int json_length;
+    std::size_t json_length;
 };
 
 /**
@@ -170,6 +170,8 @@ inline std::variant<parsed_request_t, default_error_t> split_body_headers(std::s
             return default_error_t{-32700, "Invalid JSON was received by the server."};
         req.body = body.substr(pos + 4);
         auto res = std::from_chars(req.content_length.begin(), req.content_length.end(), req.json_length);
+        if (res.ec == std::errc::invalid_argument)
+            return default_error_t{-32700, "Invalid JSON was received by the server."};
     } else {
         req.json_length = body.size();
         req.body = body;


### PR DESCRIPTION
io_uring_prep_send can return multiple completions for partial data.  However it can also return a 0 completion after a full completion which trips up the state machine as we move to expecting_reception after all the data is written.

The fix is to tag the user_data with the request type and ignore send done completions when in expecting_reception.

To see the bug use wrk which parses the responses and will hang when the bug occurs.

```
sudo apt install wrk
wrk -t1 -c32 -d2s http://localhost:8545/ -s json.lua
```