### PR TITLE
Use stdout for logging

### DIFF
--- a/examples/login/ucall_server.cpp
+++ b/examples/login/ucall_server.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
     config.max_concurrent_connections = 1024;
     config.queue_depth = 4096 * config.max_threads;
     config.max_lifetime_exchanges = UINT32_MAX;
-    config.logs_file_descriptor = result["silent"].as<bool>() ? -1 : fileno(stdin);
+    config.logs_file_descriptor = result["silent"].as<bool>() ? -1 : fileno(stdout);
     config.logs_format = "human";
     // config.use_ssl = true;
     // config.ssl_private_key_path = "./examples/login/certs/main.key";


### PR DESCRIPTION
I think there was a typo in example code setting `stdin` as the default logging destination.